### PR TITLE
Fix tokenizer attribute reference

### DIFF
--- a/export_onnx.py
+++ b/export_onnx.py
@@ -20,7 +20,7 @@ ap = AudioProcessor.init_from_config(config)
 
 # Initialize tokenizer
 tokenizer, config = TTSTokenizer.init_from_config(config)
-config.num_chars = tokenizer.tokenizer.num_chars
+config.num_chars = tokenizer.characters.num_chars
 config.encoder_hidden_channels = 192  # use your trained config value if different
 
 # Build model


### PR DESCRIPTION
## Summary
- fix the tokenizer attribute used in `export_onnx.py`

## Testing
- `python export_onnx.py` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862cdb0296c832786561c510b48f880